### PR TITLE
Add support for letter format

### DIFF
--- a/formats.go
+++ b/formats.go
@@ -6,6 +6,21 @@ import (
 
 func getSize(format string, layout string) (size, error) {
 	switch format {
+	case FormatLetter:
+		switch layout {
+		case OrientationLandscape:
+			return size{
+				width:  15936,
+				height: 12188,
+			}, nil
+		case OrientationPortrait:
+			return size{
+				width:  12188,
+				height: 15936,
+			}, nil
+		default:
+			return size{}, errors.New("Incorrect document orientation")
+		}
 	case FormatA5:
 		switch layout {
 		case OrientationLandscape:

--- a/types.go
+++ b/types.go
@@ -188,10 +188,11 @@ const (
 
 // Commont paper formats
 const (
-	FormatA5 = "format_A5"
-	FormatA4 = "format_A4"
-	FormatA3 = "format_A3"
-	FormatA2 = "format_A2"
+	FormatLetter = "format_Letter"
+	FormatA5     = "format_A5"
+	FormatA4     = "format_A4"
+	FormatA3     = "format_A3"
+	FormatA2     = "format_A2"
 )
 
 // Aligning properties


### PR DESCRIPTION
Modified types.go and formats.go (getSize function) to add support for letter document types (8.5" x 11")